### PR TITLE
G3.5 - CI блокирует merge, если покрытие <80%

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -14,7 +14,7 @@ export default defineConfig({
       reportsDirectory: './coverage',
       all: true,
       include: ["src/**/*.{js,jsx}"],
-      exclude: ["src/main.jsx"],
+      // exclude: ["src/main.jsx"],
     },
   },
 });


### PR DESCRIPTION
[//]: # (Используйте этот шаблон как гайд для описания своего PR)

[//]: # (Удалите строки не нужные для описания вашего PR)

### Описание
в vite. config.js включен main.jsx в покрытие
### Изменения включают в себя:

закомментирована строка, исключающая main.jsx из покрытия